### PR TITLE
Scrape multiple terms

### DIFF
--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -35,10 +35,6 @@ class MemberPage < Scraped::HTML
     email_from(noko.css('div.contact-actions__email a[href*="mailto:"]/@href'))
   end
 
-  field :term do
-    '26'
-  end
-
   field :image do
     noko.css('.profile-pic img/@src').text
   end

--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -6,10 +6,14 @@ class MembersPage < Scraped::HTML
   decorator Scraped::Response::Decorator::CleanUrls
 
   field :member_urls do
-    noko.css('.list-of-people a[href*="/person/"]/@href').map(&:text)
+    noko.css('.list-of-things-item a[href*="/person/"]/@href').map(&:text)
   end
 
   field :next_page do
     noko.css('.pagination a.next/@href').text
+  end
+
+  field :term do
+    URI.decode_www_form(URI.parse(url).query).to_h['session'][2..-1]
   end
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -18,15 +18,15 @@ end
 
 def scrape_list(list_url)
   page = scrape(list_url => MembersPage)
-  page.member_urls.each { |url| scrape_person(url) }
+  page.member_urls.each { |url| scrape_person(url, term: page.term) }
   scrape_list(page.next_page) unless page.next_page.to_s.empty?
 end
 
-def scrape_person(url)
-  data = scrape(url => MemberPage).to_h
+def scrape_person(url, term:)
+  data = scrape(url => MemberPage).to_h.merge(term: term)
   puts data.reject { |_, v| v.to_s.empty? }.sort_by { |k, _| k }.to_h if ENV['MORPH_DEBUG']
   ScraperWiki.save_sqlite(%i[id term], data)
 end
 
 ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
-scrape_list('https://www.pa.org.za/organisation/national-assembly/people/')
+scrape_list('https://www.pa.org.za/position/member/parliament/national-assembly/?session=na26')

--- a/scraper.rb
+++ b/scraper.rb
@@ -29,4 +29,6 @@ def scrape_person(url, term:)
 end
 
 ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
-scrape_list('https://www.pa.org.za/position/member/parliament/national-assembly/?session=na26')
+25.upto(26).each do |term|
+  scrape_list("https://www.pa.org.za/position/member/parliament/national-assembly/?session=na#{term}")
+end

--- a/test/data/beverley-lynette-abrahams.yml
+++ b/test/data/beverley-lynette-abrahams.yml
@@ -9,7 +9,6 @@
   :party_id: ANC
   :area: National
   :email: babrahams@parliament.gov.za
-  :term: '26'
   :image: https://www.pa.org.za/media_root/cache/c2/a4/c2a494a2eda7d4099f204db945421cd0.jpg
   :identifier__peoples_assembly: '1018'
   :source: https://www.pa.org.za/person/beverley-lynette-abrahams/


### PR DESCRIPTION
Update the scraper to use the new per-term views added in https://github.com/mysociety/pombola/pull/2287. This allows us to scrape term 25 and 26, rather than having `26` hard-coded in the scraper.

Part of https://github.com/everypolitician/everypolitician-data/issues/42096