### PR TITLE
Return all members of 26th National Assembly session

### DIFF
--- a/lib/members_page.rb
+++ b/lib/members_page.rb
@@ -6,7 +6,7 @@ class MembersPage < Scraped::HTML
   decorator Scraped::Response::Decorator::CleanUrls
 
   field :member_urls do
-    noko.css('.list-of-people a[href*="/person/"]/@href').map(&:text)
+    noko.css('.person-list-item a[href*="/person/"]/@href').map(&:text)
   end
 
   field :next_page do

--- a/scraper.rb
+++ b/scraper.rb
@@ -25,7 +25,7 @@ def member_data(url)
   scraper(url => MemberPage).to_h
 end
 
-data = members_data('https://www.pa.org.za/organisation/national-assembly/people/')
+data = members_data('https://www.pa.org.za/position/member/parliament/national-assembly/?session=na26')
 data.each { |mem| puts mem.reject { |_, v| v.to_s.empty? }.sort_by { |k, _| k }.to_h } if ENV['MORPH_DEBUG']
 
 ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil


### PR DESCRIPTION
This changes the scraper to return all members of the 26th NA session, instead of just current members. This prevents data being lost from EveryPolitician once members leave the Assembly.

This partially replaces some work in #3.

**NB:** This will also modify the behaviour of https://www.wikidata.org/wiki/User:Jacksonj04/prompts/South_Africa/Assembly/Peoples_Assembly and make it difficult to spot mismatches in current members, since the prompt assumes the scraper source _only_ includes current members.
